### PR TITLE
Add format

### DIFF
--- a/src/class-config.php
+++ b/src/class-config.php
@@ -443,6 +443,10 @@ class Config {
 				$format = true;
 			}
 
+			if ( 'textarea' === $acf_field['type']) {
+				$format = true;
+			}
+
 			/**
 			 * Check if cloned field and retrieve the key accordingly.
 			 */


### PR DESCRIPTION
Hey, last time i wanted to use wptexturize with acf on the textarea type. But your plugin forbade it for me. 
Could you tell my why did you not take care of textarea to format? And why did you change the basic behavior of the plugin? (Why the format is dependent of the type).

Maybe add some filters to make us able to set format by my own.

Best Regards